### PR TITLE
Make sure exec_after timestamp returned from Redis is correctly decoded back to Number

### DIFF
--- a/lib/workflow-redis-backend.js
+++ b/lib/workflow-redis-backend.js
@@ -345,6 +345,10 @@ var WorkflowRedisBackend = module.exports = function (config) {
                 job.params = JSON.parse(job.params);
             } catch (e5) {}
         }
+        // exec_after when saved as a timestamp comes back from Redis as a string
+        // and cannot be parsed properlly by Date object
+        if (isNaN(new Date(job.exec_after).getTime()))
+            job.exec_after = +job.exec_after
         return callback(job);
     }
 


### PR DESCRIPTION
Fixes [node-workflow #93](https://github.com/kusor/node-workflow/issues/93)
