### PR TITLE
Update redis module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "bunyan": "0.20.0",
-    "redis": "0.8.2",
+    "redis": "0.8.4",
     "async": "0.1.22",
     "node-uuid": "1.4.0",
     "wf": "~0.9"


### PR DESCRIPTION
We are experiencing some issues with redis 0.8.2, that are fixed in 0.8.3 and 0.8.4. Specifically "Fix SMEMBERS order dependency in test broken by Redis changes (Garrett Johnson)" (see changelog https://github.com/mranney/node_redis/blob/master/changelog.md).

Using "redis": "0.8.4" fixes the issues.
