### PR TITLE
mejora rendimiento getJobs

### DIFF
--- a/lib/workflow-redis-backend.js
+++ b/lib/workflow-redis-backend.js
@@ -336,31 +336,12 @@ var WorkflowRedisBackend = module.exports = function (config) {
     // - job - (object) raw job from redis to decode
     // - callback - (function) f(job)
     function _decodeJob(job, callback) {
-        if (job.chain) {
+        ['chain','onerror','chain_results','onerror_results','params'].forEach(function(property) {
             try {
-                job.chain = JSON.parse(job.chain);
-            } catch (e1) {}
-        }
-        if (job.onerror) {
-            try {
-                job.onerror = JSON.parse(job.onerror);
-            } catch (e2) {}
-        }
-        if (job.chain_results) {
-            try {
-                job.chain_results = JSON.parse(job.chain_results);
-            } catch (e3) {}
-        }
-        if (job.onerror_results) {
-            try {
-                job.onerror_results = JSON.parse(job.onerror_results);
-            } catch (e4) {}
-        }
-        if (job.params) {
-            try {
-                job.params = JSON.parse(job.params);
-            } catch (e5) {}
-        }
+                job[property] = JSON.parse(job[property]);
+            } catch (e) {}
+        });
+
         // exec_after when saved as a timestamp comes back from Redis as a
         // string and cannot be parsed properlly by Date object
         if (isNaN(new Date(job.exec_after).getTime())) {
@@ -1277,32 +1258,61 @@ var WorkflowRedisBackend = module.exports = function (config) {
 
         if (typeof (execution) === 'undefined') {
             return client.smembers('wf_jobs', function (err, res) {
-                res.forEach(function (uuid) {
-                    multi.hgetall('job:' + uuid);
-                });
 
-                multi.exec(function (err, replies) {
-                    if (err) {
-                        log.error({err: err});
-                        return callback(new wf.BackendInternalError(err));
-                    }
-                    replies.forEach(function (job, i, arr) {
-                        return _decodeJob(job, function (job) {
-                            replies[i] = job;
+                if (typeof (params) === 'object' && Object.keys(params).length > 0) {
+                    var total = res.length-1;
+                    res.forEach(function (uuid, i) {
+
+                        client.hget('job:' + uuid, 'params', function(err, reply){
+                            if( reply ){
+
+                                var paramsJson = JSON.parse(reply);
+                                if (hasPropsAndVals(paramsJson, params)) {
+                                    multi.hgetall('job:' + uuid);
+                                }
+
+                            }
+
+                            if(total === i){
+
+                                multi.exec(function (err, replies) {
+                                    if (err) {
+                                        log.error({err: err});
+                                        return callback(new wf.BackendInternalError(err));
+                                    }
+                                    replies.forEach(function (job, i, arr) {
+                                        return _decodeJob(job, function (job) {
+                                            replies[i] = job;
+                                        });
+                                    });
+
+                                    return callback(null, replies.slice(offset, limit));
+
+                                });
+                            }
                         });
+
                     });
-
-
-
-                    var theJobs = [];
-                    replies.forEach(function (job) {
-                        if (hasPropsAndVals(job.params, params)) {
-                            theJobs.push(job);
+                } else {
+                    res.forEach(function (uuid) {
+                        multi.hgetall('job:' + uuid);
+                    });
+                    multi.exec(function (err, replies) {
+                        if (err) {
+                            log.error({err: err});
+                            return callback(new wf.BackendInternalError(err));
                         }
-                    });
-                    return callback(null, theJobs.slice(offset, limit));
+                        replies.forEach(function (job, i, arr) {
+                            return _decodeJob(job, function (job) {
+                                replies[i] = job;
+                            });
+                        });
 
-                });
+                        return callback(null, replies.slice(offset, limit));
+
+                    });
+
+                }
             });
         } else if (executions.indexOf(execution !== -1)) {
             list_name = 'wf_' + execution + '_jobs';
@@ -1312,37 +1322,68 @@ var WorkflowRedisBackend = module.exports = function (config) {
                     return callback(new wf.BackendInternalError(err));
                 }
                 return client.lrange(
-                  list_name,
-                  0,
-                  (res + 1),
-                  function (err, results) {
-                    if (err) {
-                        return callback(new wf.BackendInternalError(err));
-                    }
-                    results.forEach(function (uuid) {
-                        multi.hgetall('job:' + uuid);
-                    });
-                    return multi.exec(function (err, replies) {
+                    list_name,
+                    0,
+                    (res + 1),
+                    function (err, results) {
                         if (err) {
-                            log.error({err: err});
                             return callback(new wf.BackendInternalError(err));
                         }
+                        if (typeof (params) === 'object' && Object.keys(params).length > 0) {
+                            var total = results.length-1;
+                            results.forEach(function (uuid, i) {
 
-                        replies.forEach(function (job, i, arr) {
-                            return _decodeJob(job, function (job) {
-                                replies[i] = job;
+                                client.hget('job:' + uuid, 'params', function(err, reply){
+                                    if( reply ){
+
+                                        var paramsJson = JSON.parse(reply);
+                                        if (hasPropsAndVals(paramsJson, params)) {
+                                            multi.hgetall('job:' + uuid);
+                                        }
+
+                                    }
+
+                                    if(total === i){
+
+                                        multi.exec(function (err, replies) {
+                                            if (err) {
+                                                log.error({err: err});
+                                                return callback(new wf.BackendInternalError(err));
+                                            }
+                                            replies.forEach(function (job, i, arr) {
+                                                return _decodeJob(job, function (job) {
+                                                    replies[i] = job;
+                                                });
+                                            });
+
+                                            return callback(null, replies.slice(offset, limit));
+
+                                        });
+                                    }
+                                });
+
                             });
-                        });
+                        } else {
+                            results.forEach(function (uuid) {
+                                multi.hgetall('job:' + uuid);
+                            });
+                            multi.exec(function (err, replies) {
+                                if (err) {
+                                    log.error({err: err});
+                                    return callback(new wf.BackendInternalError(err));
+                                }
+                                replies.forEach(function (job, i, arr) {
+                                    return _decodeJob(job, function (job) {
+                                        replies[i] = job;
+                                    });
+                                });
 
-                        var theJobs = [];
-                        replies.forEach(function (job) {
-                            if (hasPropsAndVals(job.params, params)) {
-                                theJobs.push(job);
-                            }
-                        });
-                        return callback(null, theJobs.slice(offset, limit));
+                                return callback(null, replies.slice(offset, limit));
+
+                            });
+
+                        }
                     });
-                  });
             });
         } else {
             return callback(new wf.BackendInvalidArgumentError(


### PR DESCRIPTION
Hemos detectado que la función getJobs tarda en responder cuando empiezas a tener una gran cantidad de jobs en redis. Lo hemos cambiado de tal manera que, a la hora de filtrar mediante params, después del smembers, hacemos un hget (complejidad O(1) ) de los params de cada job para mirar si los parámetros de éste cumple las condiciones de busqueda, al final sólo hacemos hgetall ( complejidad O(N) ) y decodeJob de aquellos jobs que cumplen las condiciones.

También hemos modificado ligéramente la función decodeJob.

Hemos notado bastante esta mejora en el rendimiento. Espero que os sirva de algo este aporte.
