### PR TITLE
Removed 'multi', fixed some bugs and error handling

### DIFF
--- a/lib/workflow-redis-backend.js
+++ b/lib/workflow-redis-backend.js
@@ -1251,7 +1251,6 @@ var WorkflowRedisBackend = module.exports = function (config) {
     //              jobs are sorted by "created_at" DESCending.
     // - callback - f(err, jobs)
     function getJobs(params, callback) {
-        var multi = client.multi();
         var executions = ['queued', 'failed', 'succeeded',
             'canceled', 'running', 'retried', 'waiting'];
         var list_name;
@@ -1282,62 +1281,12 @@ var WorkflowRedisBackend = module.exports = function (config) {
         }
 
         if (typeof (execution) === 'undefined') {
-            return client.smembers('wf_jobs', function (err, res) {
-
-                if (typeof (params) === 'object' && Object.keys(params).length > 0) {
-                    var total = res.length-1;
-                    res.forEach(function (uuid, i) {
-
-                        client.hget('job:' + uuid, 'params', function(err, reply){
-                            if( reply ){
-
-                                var paramsJson = JSON.parse(reply);
-                                if (hasPropsAndVals(paramsJson, params)) {
-                                    multi.hgetall('job:' + uuid);
-                                }
-
-                            }
-
-                            if(total === i){
-
-                                multi.exec(function (err, replies) {
-                                    if (err) {
-                                        log.error({err: err});
-                                        return callback(new wf.BackendInternalError(err));
-                                    }
-                                    replies.forEach(function (job, i, arr) {
-                                        return _decodeJob(job, function (job) {
-                                            replies[i] = job;
-                                        });
-                                    });
-
-                                    return callback(null, replies.slice(offset, limit));
-
-                                });
-                            }
-                        });
-
-                    });
-                } else {
-                    res.forEach(function (uuid) {
-                        multi.hgetall('job:' + uuid);
-                    });
-                    multi.exec(function (err, replies) {
-                        if (err) {
-                            log.error({err: err});
-                            return callback(new wf.BackendInternalError(err));
-                        }
-                        replies.forEach(function (job, i, arr) {
-                            return _decodeJob(job, function (job) {
-                                replies[i] = job;
-                            });
-                        });
-
-                        return callback(null, replies.slice(offset, limit));
-
-                    });
-
+            return client.smembers('wf_jobs', function (err, results) {
+                if (err) {
+                    log.error({err: err});
+                    return callback(new wf.BackendInternalError(err));
                 }
+                return processJobList(results, params, client, offset, limit, callback);
             });
         } else if (executions.indexOf(execution !== -1)) {
             list_name = 'wf_' + execution + '_jobs';
@@ -1352,70 +1301,65 @@ var WorkflowRedisBackend = module.exports = function (config) {
                     (res + 1),
                     function (err, results) {
                         if (err) {
+                            log.error({err: err});
                             return callback(new wf.BackendInternalError(err));
                         }
-                        if (typeof (params) === 'object' && Object.keys(params).length > 0) {
-                            var total = results.length-1;
-                            results.forEach(function (uuid, i) {
-
-                                client.hget('job:' + uuid, 'params', function(err, reply){
-                                    if( reply ){
-
-                                        var paramsJson = JSON.parse(reply);
-                                        if (hasPropsAndVals(paramsJson, params)) {
-                                            multi.hgetall('job:' + uuid);
-                                        }
-
-                                    }
-
-                                    if(total === i){
-
-                                        multi.exec(function (err, replies) {
-                                            if (err) {
-                                                log.error({err: err});
-                                                return callback(new wf.BackendInternalError(err));
-                                            }
-                                            replies.forEach(function (job, i, arr) {
-                                                return _decodeJob(job, function (job) {
-                                                    replies[i] = job;
-                                                });
-                                            });
-
-                                            return callback(null, replies.slice(offset, limit));
-
-                                        });
-                                    }
-                                });
-
-                            });
-                        } else {
-                            results.forEach(function (uuid) {
-                                multi.hgetall('job:' + uuid);
-                            });
-                            multi.exec(function (err, replies) {
-                                if (err) {
-                                    log.error({err: err});
-                                    return callback(new wf.BackendInternalError(err));
-                                }
-                                replies.forEach(function (job, i, arr) {
-                                    return _decodeJob(job, function (job) {
-                                        replies[i] = job;
-                                    });
-                                });
-
-                                return callback(null, replies.slice(offset, limit));
-
-                            });
-
-                        }
+                        return processJobList(results, params, client, offset, limit, callback);
                     });
             });
         } else {
             return callback(new wf.BackendInvalidArgumentError(
-              'excution is required and must be one of' +
-              '"queued", "failed", "succeeded", "canceled", "running"' +
-              ', "retried", "waiting"'));
+                'excution is required and must be one of' +
+                    '"queued", "failed", "succeeded", "canceled", "running"' +
+                    ', "retried", "waiting"'));
         }
+    }
+
+    // If jobList is empty, must call callback with an empty list
+    function processJobList(jobList, params, client, offset, limit, callback) {
+        var paramsCall = [];
+        var getAllCalls = [];
+
+        jobList.forEach(function (uuid) {
+            paramsCall.push(function(callback) {
+                client.hget('job:' + uuid, 'params', function(err, reply) {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    var jobParams = JSON.parse(reply);
+                    if (hasPropsAndVals(jobParams, params)) {
+                        getAllCalls.push(function(callback) {
+                            client.hgetall('job:' + uuid, function(err, reply) {
+                                return callback(err, reply);
+                            });
+                        });
+                    }
+                    return callback(null);
+                });
+            });
+        });
+
+        async.parallel(paramsCall, function(err) {
+            if (err) {
+                log.error({err: err});
+                return callback(new wf.BackendInternalError(err));
+            }
+
+            return async.parallel(getAllCalls, function(err, replies) {
+                if (err) {
+                    log.error({err: err});
+                    return callback(new wf.BackendInternalError(err));
+                }
+                replies.forEach(function (job, i, arr) {
+                    return _decodeJob(job, function (job) {
+                        replies[i] = job;
+                    });
+                });
+
+                return callback(null, replies.slice(offset, limit));
+            });
+        });
     }
 
     backend.getJobs = getJobs;


### PR DESCRIPTION
Fixed stuff:
- Current 'getJobs' code hangs when there is no job in redis (res.forEach has 0 iterations and callback is never  called).
- There are some missing error handling (the 'err' parameter is not always checked before assuming that the request was ok).
- The use of 'multi' cause the code to be very slow with medium load (1000~2000 jobs), as it is always executed in one single transaction. Doing many individual request will cause that redis automatically pipeline them (and process in parallel).
- A common function 'processJobList' has been created, to reuse code and simplify both execution blocks (execution === 'undefined' and the opposite).
