### PR TITLE
Attempt to fix issue where num_attempts is returned as a string

### DIFF
--- a/lib/workflow-redis-backend.js
+++ b/lib/workflow-redis-backend.js
@@ -349,7 +349,8 @@ var WorkflowRedisBackend = module.exports = function (config) {
             'onerror_results',
             'oncancel',
             'oncancel_results',
-            'params'
+            'params',
+            'num_attempts'
         ].forEach(function (property) {
             try {
                 job[property] = JSON.parse(job[property]);

--- a/test/redis-backend.test.js
+++ b/test/redis-backend.test.js
@@ -137,6 +137,7 @@ test('create job', function (t) {
         t.ok(job.uuid, 'job uuid');
         t.ok(util.isArray(job.chain), 'job chain is array');
         t.ok(util.isArray(job.onerror), 'job onerror is array');
+        t.equal(typeof job.num_attempts, 'number', 'num_attempts is a number');
         t.ok(
           (typeof (job.params) === 'object' && !util.isArray(job.params)),
           'params ok');
@@ -145,6 +146,11 @@ test('create job', function (t) {
             t.ifError(err, 'get job property error');
             t.equal(val, '/foo/bar', 'property value ok');
             t.end();
+        });
+
+        backend.getJob(aJob.uuid, function(err, job){
+            t.ifError(err, 'get job error');
+            t.equal(typeof job.num_attempts, 'number', 'num_attempts is a number');
         });
     });
 });


### PR DESCRIPTION
This results in num_attempts getting incremented like 01, 011, 0111 by the node-workflow runner.  An error is then thrown [here](https://github.com/kusor/node-workflow/blob/master/lib/runner.js#L287) because [this line](https://github.com/kusor/node-workflow/blob/master/lib/runner.js#L284) evaluates to NaN when 2 is raised to 01111.
